### PR TITLE
Provide an option for a custom Filename - Properly expand Jenkins Env variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
    <properties>
 	 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-         <maven.compiler.source>1.7</maven.compiler.source>
-         <maven.compiler.target>1.7</maven.compiler.target>
-  	 <compile.java.version>1.7</compile.java.version>
+         <maven.compiler.source>1.8</maven.compiler.source>
+         <maven.compiler.target>1.8</maven.compiler.target>
+	 <compile.java.version>1.8</compile.java.version>
    </properties>
 </project>

--- a/src/main/java/SlackUploader.java
+++ b/src/main/java/SlackUploader.java
@@ -4,6 +4,7 @@
  * and open the template in the editor.
  */
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -68,13 +69,16 @@ public class SlackUploader extends Recorder {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        //Get the environment
+        final EnvVars env = build.getEnvironment(listener);
+
         //To change body of generated methods, choose Tools | Templates.
         LogOutput log = new LogOutput();
         Runtime runtime = Runtime.getRuntime();
         Process process = null;
 
         try {
-            String script = generateScript();
+            String script = generateScript(env);
             
             process = runScript(runtime, script);
             
@@ -92,10 +96,10 @@ public class SlackUploader extends Recorder {
 
     
 
-    private String generateScript() {
-        String loop = "for file in $(ls " + filePath + ");";
+    private String generateScript(EnvVars env) {
+        String loop = "for file in $(ls " + env.expand(filePath) + ");";
         loop+="do ";
-        String curlRequest = loop + "curl -F file=@$file -F filename=" + fileName
+        String curlRequest = loop + "curl -F file=@$file -F filename=" + env.expand(fileName)
                 +" -F channels=" + channel + " -F token=" + token + " https://slack.com/api/files.upload ;";
         String loopDone = curlRequest + "done;";
         return loopDone;

--- a/src/main/java/SlackUploader.java
+++ b/src/main/java/SlackUploader.java
@@ -99,8 +99,9 @@ public class SlackUploader extends Recorder {
     private String generateScript(EnvVars env) {
         String loop = "for file in $(ls " + env.expand(filePath) + ");";
         loop+="do ";
-        String curlRequest = loop + "curl -F file=@$file -F filename=" + env.expand(fileName)
-                +" -F channels=" + channel + " -F token=" + token + " https://slack.com/api/files.upload ;";
+        String expandedName = env.expand(fileName);
+        String curlRequest = loop + "curl -F file=@$file -F filename=" + expandedName
+                 +" -F channels=" + channel + " -F token=" + token + " https://slack.com/api/files.upload ;";
         String loopDone = curlRequest + "done;";
         return loopDone;
     }

--- a/src/main/java/SlackUploader.java
+++ b/src/main/java/SlackUploader.java
@@ -32,14 +32,16 @@ public class SlackUploader extends Recorder {
     private final String channel;
     private final String token;
     private final String filePath;
+    private final String fileName;
     private static final String CHOICE_OF_SHELL = "/bin/bash";
     
     @DataBoundConstructor
-    public SlackUploader(String channel, String token, String filePath) {
+    public SlackUploader(String channel, String token, String filePath, String fileName) {
         super();
         this.channel = channel;
         this.token = token;
         this.filePath = filePath;
+        this.fileName = fileName;
     }
 
     public String getChannel() {
@@ -48,6 +50,10 @@ public class SlackUploader extends Recorder {
 
     public String getFilePath() {
         return filePath;
+    }
+
+    public String getFileName() {
+        return fileName;
     }
 
     public String getToken() {
@@ -89,7 +95,8 @@ public class SlackUploader extends Recorder {
     private String generateScript() {
         String loop = "for file in $(ls " + filePath + ");";
         loop+="do ";
-        String curlRequest = loop + "curl -F file=@$file -F channels=" + channel +" -F token=" + token + " https://slack.com/api/files.upload ;";
+        String curlRequest = loop + "curl -F file=@$file -F filename=" + fileName
+                +" -F channels=" + channel + " -F token=" + token + " https://slack.com/api/files.upload ;";
         String loopDone = curlRequest + "done;";
         return loopDone;
     }
@@ -135,8 +142,10 @@ public class SlackUploader extends Recorder {
             return FormValidation.ok();
         }
         
-        public FormValidation doCheckFilePath(@QueryParameter String filePath) {
-            if (filePath.length() == 0) {
+        public FormValidation doCheckFilePath(@QueryParameter String filePath, @QueryParameter String fileName) {
+            if (fileName.length() != 0 && filePath.contains("*")) {
+                return FormValidation.error("Do not use regex if you have set a filename");
+            } else if (filePath.length() == 0) {
                 return FormValidation.error("Cannot be empty");
             }
             return FormValidation.ok();
@@ -154,7 +163,8 @@ public class SlackUploader extends Recorder {
             String channel = req.getParameter("channel");
             String token = req.getParameter("token");
             String filePath = req.getParameter("filePath");
-            return new SlackUploader(channel, token, filePath);
+            String fileName = req.getParameter("fileName");
+            return new SlackUploader(channel, token, filePath, fileName);
         }
 
         

--- a/src/main/resources/SlackUploader/config.jelly
+++ b/src/main/resources/SlackUploader/config.jelly
@@ -3,11 +3,14 @@
   <f:entry title="${%Add channel}" field="channel">
         <f:textbox name="channel" value="${instance.getChannel()}"/>
   </f:entry>
-<f:entry title="${%Add token}" field="token">
+  <f:entry title="${%Add token}" field="token">
         <f:textbox name="token" value="${instance.getToken()}"/>
   </f:entry>
-<f:entry title="${%Enter path to file directory}" field="filePath">
+  <f:entry title="${%Enter path to file directory}" field="filePath">
         <f:textbox name="filePath" value="${instance.getFilePath()}"/>
+  </f:entry>
+  <f:entry title="${%Enter name to file }" field="fileName">
+        <f:textbox name="fileName" value="${instance.getFileName()}"/>
   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/SlackUploader/help-fileName.html
+++ b/src/main/resources/SlackUploader/help-fileName.html
@@ -1,0 +1,4 @@
+<div>
+    Enter the name of the file you want to upload to Slack. 
+    <br>Leave it empty if you want to upload multiple files using regex in filePath.</br>
+</div>

--- a/src/main/resources/SlackUploader/help-filePath.html
+++ b/src/main/resources/SlackUploader/help-filePath.html
@@ -1,4 +1,5 @@
 <div>
     Enter the directory path of the files you want to upload to Slack. The path maybe followed by a regex to specify the files you want to upload.eg - /var/lib/*.jpg
     <br> If no regex is specified, all the files from the directory will be uploaded.</br>
+    <br> Do not use a regex if you want to set a custom fileName.</br>
 </div>


### PR DESCRIPTION
The [files.upload](https://api.slack.com/methods/files.upload) API provides a way for a custom filename to the uploaded file. 

This patch adds an option for it.

It also provides support for expanding the Jenkins env variables inside the arguments passed to the plugin (so now variables like $WORKSPACE will work).

I only built it on Windows 10 WSL / bash with openjdk 8 that's why pom.xml is updated as well.
